### PR TITLE
Fix lift_sequence in msys2

### DIFF
--- a/externals/mcl/include/mcl/mp/typelist/lift_sequence.hpp
+++ b/externals/mcl/include/mcl/mp/typelist/lift_sequence.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <type_traits>
+#include <utility>
 
 #include "mcl/mp/typelist/list.hpp"
 
@@ -17,6 +18,11 @@ struct lift_sequence_impl;
 
 template<class T, template<class, T...> class VLT, T... values>
 struct lift_sequence_impl<VLT<T, values...>> {
+    using type = list<std::integral_constant<T, values>...>;
+};
+
+template<class T, T... values>
+struct lift_sequence_impl<std::integer_sequence<T, values...>> {
     using type = list<std::integral_constant<T, values>...>;
 };
 


### PR DESCRIPTION
Adds explicit specialization to the `lift_sequence_impl` template for `std::integer_sequence`, which fixes compiling on msys2 after some compiler change broke it