### PR TITLE
backend: Do not use random generator for reg allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ set(TSL_ROBIN_MAP_ENABLE_INSTALL ON)
 
 find_package(Boost 1.57 REQUIRED)
 find_package(fmt 9 CONFIG)
-find_package(mcl 0.1.12 EXACT CONFIG)
+find_package(mcl 0.1.14 EXACT CONFIG)
 find_package(tsl-robin-map CONFIG)
 
 if ("arm64" IN_LIST ARCHITECTURE OR DYNARMIC_TESTS)

--- a/src/dynarmic/backend/arm64/reg_alloc.cpp
+++ b/src/dynarmic/backend/arm64/reg_alloc.cpp
@@ -436,9 +436,10 @@ int RegAlloc::AllocateRegister(const std::array<HostLocInfo, 32>& regs, const st
     std::vector<int> candidates;
     std::copy_if(order.begin(), order.end(), std::back_inserter(candidates), [&](int i) { return regs[i].MaybeAllocatable(); });
 
-    // TODO: LRU
-    std::uniform_int_distribution<size_t> dis{0, candidates.size() - 1};
-    return candidates[dis(rand_gen)];
+    // TODO: The candidate was chosen randomly before, and a LRU was
+    // suggested as an improvement. However, using an incrementing index
+    // seems to be close enough. Determine if an LRU is still needed.
+    return candidates[alloc_candidate_index++ % candidates.size()];
 }
 
 void RegAlloc::SpillGpr(int index) {

--- a/src/dynarmic/backend/arm64/reg_alloc.h
+++ b/src/dynarmic/backend/arm64/reg_alloc.h
@@ -158,7 +158,7 @@ public:
     using ArgumentInfo = std::array<Argument, IR::max_arg_count>;
 
     explicit RegAlloc(oaknut::CodeGenerator& code, FpsrManager& fpsr_manager, std::vector<int> gpr_order, std::vector<int> fpr_order)
-            : code{code}, fpsr_manager{fpsr_manager}, gpr_order{gpr_order}, fpr_order{fpr_order}, rand_gen{std::random_device{}()} {}
+            : code{code}, fpsr_manager{fpsr_manager}, gpr_order{gpr_order}, fpr_order{fpr_order} {}
 
     ArgumentInfo GetArgumentInfo(IR::Inst* inst);
     bool WasValueDefined(IR::Inst* inst) const;
@@ -333,7 +333,7 @@ private:
     HostLocInfo flags;
     std::array<HostLocInfo, SpillCount> spills;
 
-    mutable std::mt19937 rand_gen;
+    mutable size_t alloc_candidate_index{};
 
     tsl::robin_set<const IR::Inst*> defined_insts;
 };

--- a/src/dynarmic/backend/riscv64/reg_alloc.cpp
+++ b/src/dynarmic/backend/riscv64/reg_alloc.cpp
@@ -269,9 +269,10 @@ u32 RegAlloc::AllocateRegister(const std::array<HostLocInfo, 32>& regs, const st
     std::vector<u32> candidates;
     std::copy_if(order.begin(), order.end(), std::back_inserter(candidates), [&](u32 i) { return !regs[i].locked; });
 
-    // TODO: LRU
-    std::uniform_int_distribution<size_t> dis{0, candidates.size() - 1};
-    return candidates[dis(rand_gen)];
+    // TODO: The candidate was chosen randomly before, and a LRU was
+    // suggested as an improvement. However, using an incrementing index
+    // seems to be close enough. Determine if an LRU is still needed.
+    return candidates[alloc_candidate_index++ % candidates.size()];
 }
 
 void RegAlloc::SpillGpr(u32 index) {

--- a/src/dynarmic/backend/riscv64/reg_alloc.h
+++ b/src/dynarmic/backend/riscv64/reg_alloc.h
@@ -159,7 +159,7 @@ private:
     std::array<HostLocInfo, 32> fprs;
     std::array<HostLocInfo, SpillCount> spills;
 
-    mutable std::mt19937 rand_gen;
+    mutable size_t alloc_candidate_index{};
 };
 
 template<typename T>


### PR DESCRIPTION
A random generator was being used to choose a register from a list of maybe-allocated candidates. Having a full random generator was overkill, and was pending to be replaced by a LRU.

In fact, doing some profiling on android showed that the initialization of the random device took a considerable amount of time:
<img width="304" height="163" alt="image" src="https://github.com/user-attachments/assets/5202138f-94ef-4db5-b9d1-405c76401026" />
(The constructor took about 24ms/10s)

The code has been changed to use an incrementing index instead. In the case of the candidate list being consistent between calls, this acts the same way as an LRU, otherwise it is "close enough". In any case, it's better than choosing the candidate randomly.

After the change, the timings were improved:
<img width="646" height="243" alt="image" src="https://github.com/user-attachments/assets/d1b677b4-3616-41ca-8251-e34fb986c4a6" />
(The constructor now takes 3ms/10s)

Keep in mind that the timings were measured in a 10s window, so the improvements are minimal and unnoticeable. However, this is a "free" improvement so it rather be done anyways. x86_64 devices are completely unaffected by this change.

This PR also fixes the mcl version in cmake not matching the release tag.