### PR TITLE
a64: add identity pass

### DIFF
--- a/src/dynarmic/backend/x64/a64_interface.cpp
+++ b/src/dynarmic/backend/x64/a64_interface.cpp
@@ -286,6 +286,7 @@ private:
         if (conf.HasOptimization(OptimizationFlag::MiscIROpt)) {
             Optimization::A64MergeInterpretBlocksPass(ir_block, conf.callbacks);
         }
+        Optimization::IdentityRemovalPass(ir_block);
         Optimization::VerificationPass(ir_block);
         return emitter.Emit(ir_block).entrypoint;
     }


### PR DESCRIPTION
was just missing, fixes horrific x86_64 codegen for a64